### PR TITLE
Add configmap to api-server

### DIFF
--- a/charts/kamu-api-server/Chart.yaml
+++ b/charts/kamu-api-server/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kamu-api-server
 description: API server component of the Kamu Compute Node
 type: application
-version: 0.9.2
-appVersion: "0.9.0"
+version: 0.10.0
+appVersion: "0.10.0"
 home: https://kamu.dev
 icon: https://www.kamu.dev/images/kamu_logo_icon_bg_square.png
 sources:

--- a/charts/kamu-api-server/templates/_helpers.tpl
+++ b/charts/kamu-api-server/templates/_helpers.tpl
@@ -60,3 +60,19 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+
+{{/*
+Renders the content of the configmap
+*/}}
+{{- define "kamu-api-server.config.yaml" -}}
+{{- $root := . -}}
+config.yaml: | {{ .Values.app.config | toYaml | nindent 2 }}
+{{- end -}}
+
+{{/*
+Computes a short hash of the configmap content to re-create it and trigger the re-deploy upon any change
+*/}}
+{{- define "kamu-api-server.config.sha" -}}
+{{ include "kamu-api-server.config.yaml" . | toJson | sha256sum | trunc 10 }}
+{{- end -}}

--- a/charts/kamu-api-server/templates/configmap.yaml
+++ b/charts/kamu-api-server/templates/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "kamu-api-server.fullname" . }}-{{ template "kamu-api-server.config.sha" . }}
+  labels:
+    {{- include "kamu-api-server.labels" . | nindent 4 }}
+data:
+  {{- include "kamu-api-server.config.yaml" . | nindent 2 }}

--- a/charts/kamu-api-server/templates/deployment.yaml
+++ b/charts/kamu-api-server/templates/deployment.yaml
@@ -37,18 +37,23 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - "/opt/kamu/kamu-api-server"
-            - {{ printf "--repo-url=%s" .Values.app.config.datasetRepositoryUrl | quote }}
+            - "--config=/opt/kamu/config.yaml"
+            - {{ printf "--repo-url=%s" .Values.app.datasetRepositoryUrl | quote }}
             - "run"
             - "--address=0.0.0.0"
             - "--http-port=80"
             - "--flightsql-port=50050"
           env:
             - name: KAMU_AUTH_GITHUB_CLIENT_ID
-              value: {{ .Values.app.config.authGithubClientId | quote }}
+              value: {{ .Values.app.authGithubClientId | quote }}
             - name: KAMU_AUTH_GITHUB_CLIENT_SECRET
-              value: {{ .Values.app.config.authGithubClientSecret | quote }}
+              value: {{ .Values.app.authGithubClientSecret | quote }}
             - name: KAMU_JWT_SECRET
-              value: {{ .Values.app.config.jwtSecret | quote }}
+              value: {{ .Values.app.jwtSecret | quote }}
+          volumeMounts:
+            - name: configs
+              subPath: config.yaml
+              mountPath: /opt/kamu/config.yaml
           ports:
             - name: http
               containerPort: 80
@@ -66,6 +71,10 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: configs
+          configMap:
+            name: {{ include "kamu-api-server.fullname" . }}-{{ template "kamu-api-server.config.sha" . }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/kamu-api-server/values.schema.json
+++ b/charts/kamu-api-server/values.schema.json
@@ -5,32 +5,30 @@
     "app": {
       "type": "object",
       "required": [
-        "config"
+        "config",
+        "datasetRepositoryUrl",
+        "authGithubClientId",
+        "authGithubClientSecret",
+        "jwtSecret"
       ],
       "properties": {
         "config": {
           "type": "object",
-          "required": [
-            "datasetRepositoryUrl",
-            "authGithubClientId",
-            "authGithubClientSecret",
-            "jwtSecret"
-          ],
-          "properties": {
-            "datasetRepositoryUrl": {
-              "type": "string",
-              "format": "uri"
-            },
-            "authGithubClientId": {
-              "type": "string"
-            },
-            "authGithubClientSecret": {
-              "type": "string"
-            },
-            "jwtSecret": {
-              "type": "string"
-            }
-          }
+          "required": [],
+          "properties": {}
+        },
+        "datasetRepositoryUrl": {
+          "type": "string",
+          "format": "uri"
+        },
+        "authGithubClientId": {
+          "type": "string"
+        },
+        "authGithubClientSecret": {
+          "type": "string"
+        },
+        "jwtSecret": {
+          "type": "string"
         }
       }
     }

--- a/charts/kamu-api-server/values.yaml
+++ b/charts/kamu-api-server/values.yaml
@@ -3,13 +3,16 @@
 ###############################################################################
 
 app:
-  config:
-    # URL of the storage bucket for datasets (S3 or Minio)
-    # Example: https://api.kamu.dev/graphql
-    datasetRepositoryUrl: ""
-    authGithubClientId: ""
-    authGithubClientSecret: ""
-    jwtSecret: ""
+  # TODO: generate schema for config from DTOs
+  config: {}
+  # TODO: Move into config file
+  # URL of the storage bucket for datasets (S3 or Minio)
+  # Example: https://api.kamu.dev/graphql
+  datasetRepositoryUrl: ""
+  # TODO: Move into secrets
+  authGithubClientId: ""
+  authGithubClientSecret: ""
+  jwtSecret: ""
 
 ###############################################################################
 # Pod


### PR DESCRIPTION
@romcheg curious to hear your feedback on this hashed config map pattern. By creating new ConfigMap objects whenever content changes it forces re-deploy of the pods, but also produces lots of dangling objects for which we had a special garbage collector at my prev. work.

Btw if we were to move this chart into an application repo we could nicely auto-generate the config schema.