### PR TITLE
KAMUDEP-23 | Implement NodePort service type support

### DIFF
--- a/charts/kamu-api-server/Chart.yaml
+++ b/charts/kamu-api-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kamu-api-server
 description: API server component of the Kamu Compute Node
 type: application
-version: 0.10.1
+version: 0.10.2
 appVersion: "0.10.0"
 home: https://kamu.dev
 icon: https://www.kamu.dev/images/kamu_logo_icon_bg_square.png

--- a/charts/kamu-api-server/templates/service.yaml
+++ b/charts/kamu-api-server/templates/service.yaml
@@ -10,9 +10,29 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
-  {{- with .Values.service.ports }}
+  {{- with .Values.service }}
   ports:
-    {{- toYaml . | nindent 4 }}
+    - port: {{ .ports.http }}
+      name: http
+      targetPort: http
+      protocol: TCP
+      {{- if (and (eq .type "NodePort") .nodePorts.http) }}
+      nodePort: {{ .nodePorts.http }}
+      {{- end }}
+    - port: {{ .ports.https }}
+      name: https
+      targetPort: http
+      protocol: TCP
+      {{- if (and (eq .type "NodePort") .nodePorts.https) }}
+      nodePort: {{ .nodePorts.https }}
+      {{- end }}
+    - port: {{ .ports.flightsql }}
+      name: flightsql
+      targetPort: flightsql
+      protocol: TCP
+      {{- if (and (eq .type "NodePort") .nodePorts.flightsql) }}
+      nodePort: {{ .nodePorts.flightsql }}
+      {{- end }}
   {{- end }}
   selector:
     {{- include "kamu-api-server.selectorLabels" . | nindent 4 }}

--- a/charts/kamu-api-server/values.yaml
+++ b/charts/kamu-api-server/values.yaml
@@ -80,19 +80,17 @@ affinity: {}
 
 service:
   type: ClusterIP
+
   ports:
-    - port: 80
-      name: http
-      targetPort: http
-      protocol: TCP
-    - port: 443
-      name: https
-      targetPort: http
-      protocol: TCP
-    - port: 50050
-      name: flightsql
-      targetPort: flightsql
-      protocol: TCP
+    http: 80
+    https: 443
+    flightsql: 50050
+
+  nodePorts:
+    http: ""
+    https: ""
+    flightsql: ""
+
   annotations: {}
 
 ###############################################################################

--- a/charts/kamu-web-ui/Chart.yaml
+++ b/charts/kamu-web-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kamu-web-ui
 description: Web frontend component of the Kamu Compute Node
 type: application
-version: 0.13.2
+version: 0.13.3
 appVersion: "0.13.0"
 home: https://kamu.dev
 icon: https://www.kamu.dev/images/kamu_logo_icon_bg_square.png

--- a/charts/kamu-web-ui/templates/service.yaml
+++ b/charts/kamu-web-ui/templates/service.yaml
@@ -10,9 +10,22 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
-  {{- with .Values.service.ports }}
+  {{- with .Values.service }}
   ports:
-    {{- toYaml . | nindent 4 }}
+    - name: http
+      port: {{ .ports.http }}
+      targetPort: http
+      protocol: TCP
+      {{- if (and (eq .type "NodePort") .nodePorts.http) }}
+      nodePort: {{ .nodePorts.http }}
+      {{- end }}
+    - name: https
+      port: {{ .ports.https }}
+      targetPort: http
+      protocol: TCP
+      {{- if (and (eq .type "NodePort") .nodePorts.https) }}
+      nodePort: {{ .nodePorts.https }}
+      {{- end }}
   {{- end }}
   selector:
     {{- include "kamu-web-ui.selectorLabels" . | nindent 4 }}

--- a/charts/kamu-web-ui/values.yaml
+++ b/charts/kamu-web-ui/values.yaml
@@ -71,14 +71,12 @@ affinity: {}
 service:
   type: ClusterIP
   ports:
-    - port: 80
-      name: http
-      targetPort: http
-      protocol: TCP
-    - port: 443
-      name: https
-      targetPort: http
-      protocol: TCP
+    http: 80
+    https: 443
+  nodePorts:
+    http: ""
+    https: ""
+
   annotations: {}
 
 ###############################################################################


### PR DESCRIPTION
* Add `service.nodePorts` to values.yaml to allow specifying optional custom node ports. If omitted, a random port number is generated.
* Refactor `service.ports`. Replace inclusion of a yaml chunk into ports with explicitly defined ports in the service template.