### PR TITLE
Version skew between charts and applications

### DIFF
--- a/charts/kamu-api-server/Chart.yaml
+++ b/charts/kamu-api-server/Chart.yaml
@@ -3,7 +3,6 @@ name: kamu-api-server
 description: API server component of the Kamu Compute Node
 type: application
 version: 0.10.2
-appVersion: "0.10.0"
 home: https://kamu.dev
 icon: https://www.kamu.dev/images/kamu_logo_icon_bg_square.png
 sources:

--- a/charts/kamu-api-server/templates/_helpers.tpl
+++ b/charts/kamu-api-server/templates/_helpers.tpl
@@ -6,6 +6,14 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
+App Version
+*/}}
+{{- define "kamu-api-server.appVersion" -}}
+{{- $version := semver .Chart.Version }}
+{{- $version.Major }}.{{ $version.Minor }}
+{{- end }}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
@@ -36,9 +44,7 @@ Common labels
 {{- define "kamu-api-server.labels" -}}
 helm.sh/chart: {{ include "kamu-api-server.chart" . }}
 {{ include "kamu-api-server.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
+app.kubernetes.io/version: {{ include "kamu-api-server.appVersion" . | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 

--- a/charts/kamu-api-server/templates/deployment.yaml
+++ b/charts/kamu-api-server/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (include "kamu-api-server.appVersion" .) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - "/opt/kamu/kamu-api-server"

--- a/charts/kamu-api-server/values.schema.json
+++ b/charts/kamu-api-server/values.schema.json
@@ -18,8 +18,7 @@
           "properties": {}
         },
         "datasetRepositoryUrl": {
-          "type": "string",
-          "format": "uri"
+          "type": "string"
         },
         "authGithubClientId": {
           "type": "string"

--- a/charts/kamu-web-ui/Chart.yaml
+++ b/charts/kamu-web-ui/Chart.yaml
@@ -3,7 +3,6 @@ name: kamu-web-ui
 description: Web frontend component of the Kamu Compute Node
 type: application
 version: 0.13.3
-appVersion: "0.13.0"
 home: https://kamu.dev
 icon: https://www.kamu.dev/images/kamu_logo_icon_bg_square.png
 sources:

--- a/charts/kamu-web-ui/templates/_helpers.tpl
+++ b/charts/kamu-web-ui/templates/_helpers.tpl
@@ -6,6 +6,14 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
+App Version
+*/}}
+{{- define "kamu-web-ui.appVersion" -}}
+{{- $version := semver .Chart.Version }}
+{{- $version.Major }}.{{ $version.Minor }}
+{{- end }}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
@@ -36,9 +44,7 @@ Common labels
 {{- define "kamu-web-ui.labels" -}}
 helm.sh/chart: {{ include "kamu-web-ui.chart" . }}
 {{ include "kamu-web-ui.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
+app.kubernetes.io/version: {{ include "kamu-web-ui.appVersion" . | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 

--- a/charts/kamu-web-ui/templates/deployment.yaml
+++ b/charts/kamu-web-ui/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (include "kamu-web-ui.appVersion" .) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/kamu-web-ui/values.yaml
+++ b/charts/kamu-web-ui/values.yaml
@@ -29,7 +29,6 @@ resources: {}
 image:
   repository: ghcr.io/kamu-data/kamu-web-ui
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
 imagePullSecrets: []


### PR DESCRIPTION
Version x.y.z of a chart will install the version x.y of the corresponding application. This means that charts will always inslall rightmost patch version of applications within their major and minor version.