### PR TITLE
Create an Ingress for flightsql

### DIFF
--- a/charts/kamu-api-server/Chart.yaml
+++ b/charts/kamu-api-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kamu-api-server
 description: API server component of the Kamu Compute Node
 type: application
-version: 0.16.1
+version: 0.16.2
 appVersion: "0.16.1"
 home: https://kamu.dev
 icon: https://www.kamu.dev/images/kamu_logo_icon_bg_square.png

--- a/charts/kamu-api-server/templates/ingress-flightsql.yaml
+++ b/charts/kamu-api-server/templates/ingress-flightsql.yaml
@@ -1,21 +1,22 @@
-{{- if .Values.ingress.enabled -}}
-{{- $fullName := include "kamu-web-ui.fullname" . -}}
-{{- $svcPort := .Values.service.ports.http -}}
+{{- $fullName := include "kamu-api-server.fullname" . -}}
+{{- $svcPort := .Values.service.ports.flightsql -}}
+{{- with .Values.flightsql.ingress -}}
+{{- if .enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ $fullName }}
+  name: {{ printf "%s-flightsql" $fullName }}
   labels:
-    {{- include "kamu-web-ui.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
+    {{- include "kamu-api-server.labels" $ | nindent 4 }}
+  {{- with .annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  ingressClassName: {{ .Values.ingress.className }}
-  {{- if .Values.ingress.tls }}
+  ingressClassName: {{ .className }}
+  {{- if .tls }}
   tls:
-    {{- range .Values.ingress.tls }}
+    {{- range .tls }}
     - hosts:
         {{- range .hosts }}
         - {{ . | quote }}
@@ -24,7 +25,7 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    {{- range .Values.ingress.hosts }}
+    {{- range .hosts }}
     - host: {{ .host | quote }}
       http:
         paths:
@@ -38,4 +39,5 @@ spec:
                   number: {{ $svcPort }}
           {{- end }}
     {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/kamu-api-server/templates/ingress.yaml
+++ b/charts/kamu-api-server/templates/ingress.yaml
@@ -1,18 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "kamu-api-server.fullname" . -}}
-{{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- $svcPort := .Values.service.ports.http -}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -23,9 +12,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
   ingressClassName: {{ .Values.ingress.className }}
-  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}
@@ -43,19 +30,12 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
             pathType: {{ .pathType }}
-            {{- end }}
             backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/kamu-api-server/values.yaml
+++ b/charts/kamu-api-server/values.yaml
@@ -103,15 +103,15 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  hosts:
-    - host: chart-example.local
-      paths:
-        - path: /
-          pathType: ImplementationSpecific
+  hosts: []
+    # - host: chart-example.local
+    #   paths:
+    #     - path: /
+    #       pathType: ImplementationSpecific
   tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local
 
 ###############################################################################
 # Autoscaling
@@ -123,3 +123,24 @@ autoscaling:
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
+
+###############################################################################
+# FlightSQL
+###############################################################################
+
+flightsql:
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    hosts: []
+      # - host: chart-example.local
+      #   paths:
+      #     - path: /
+      #       pathType: ImplementationSpecific
+    tls: []
+      # - secretName: chart-example-tls
+      #   hosts:
+      #     - chart-example.local

--- a/charts/kamu-web-ui/Chart.yaml
+++ b/charts/kamu-web-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kamu-web-ui
 description: Web frontend component of the Kamu Compute Node
 type: application
-version: 0.16.1
+version: 0.16.2
 appVersion: "0.16.0"
 home: https://kamu.dev
 icon: https://www.kamu.dev/images/kamu_logo_icon_bg_square.png

--- a/charts/kamu-web-ui/values.yaml
+++ b/charts/kamu-web-ui/values.yaml
@@ -90,15 +90,15 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  hosts:
-    - host: chart-example.local
-      paths:
-        - path: /
-          pathType: ImplementationSpecific
+  hosts: []
+    # - host: chart-example.local
+    #   paths:
+    #     - path: /
+    #       pathType: ImplementationSpecific
   tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local
 
 ###############################################################################
 # Autoscaling
@@ -110,4 +110,3 @@ autoscaling:
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
-


### PR DESCRIPTION
Create an additional optional Ingress resource for flightsql

Since flightsql is hosted on a separate port and is a GRPC based protocol, in some deployments (e.g. AWS Load Balancer Controller) it is required to have multiple ingress resources, that may share a common ingress group to deploy an HTTP and GRPC server into a single Application Load Balancer.

Refactor Ingress resources. Remove compatibility checks for legacy Kubernetes versions.