### PR TITLE
Implement `extraEnv` and `extraEnvFrom` patterns

### DIFF
--- a/charts/kamu-api-server/Chart.yaml
+++ b/charts/kamu-api-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kamu-api-server
 description: API server component of the Kamu Compute Node
 type: application
-version: 0.32.1
+version: 0.32.2
 appVersion: "0.32.1"
 home: https://kamu.dev
 icon: https://www.kamu.dev/images/kamu_logo_icon_bg_square.png

--- a/charts/kamu-api-server/templates/deployment.yaml
+++ b/charts/kamu-api-server/templates/deployment.yaml
@@ -89,10 +89,6 @@ spec:
               value: "1"
             - name: RUST_LOG
               value: {{ .Values.app.logLevel | quote }}
-            {{- range $key, $value := .Values.extraEnv }}
-            - name: {{ $key | quote }}
-              value: {{ $value | quote }}
-            {{- end }}
             {{- if .Values.app.awsCredentials.enabled }}
             {{- $secretName := include "kamu-api-server.awsCredentialsSecretName" . }}
             - name: AWS_ENDPOINT
@@ -116,6 +112,13 @@ spec:
                   name: {{ $secretName }}
                   key: aws_secret_access_key
             {{- end }}
+            {{- with .Values.extraEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: configs
               subPath: config.yaml

--- a/charts/kamu-api-server/values.schema.json
+++ b/charts/kamu-api-server/values.schema.json
@@ -383,6 +383,107 @@
           }
         }
       }
+    },
+    "extraEnv": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "valueFrom": {
+            "type": "object",
+            "properties": {
+              "configMapKeyRef": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "object"
+                  },
+                  "optional": {
+                    "type": "boolean"
+                  }
+                }
+              },
+              "fieldRef": {
+                "type": "object",
+                "properties": {
+                  "apiVersion": {
+                    "type": "string"
+                  },
+                  "fieldPath": {
+                    "type": "string"
+                  }
+                }
+              },
+              "resourceFieldRef": {
+                "type": "object",
+                "properties": {
+                  "resource": {"type": "string"},
+                  "containerName": {"type": "string"},
+                  "divisor": {"type": "string"}
+                }
+              },
+              "secretKeyRef": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "object"
+                  },
+                  "optional": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "extraEnvFrom": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "configMapRef": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "optional": {
+                "type": "boolean"
+              }
+            }
+          },
+          "prefix": {
+            "type": "string"
+          },
+          "secretRef": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "optional": "boolean"
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/charts/kamu-api-server/values.yaml
+++ b/charts/kamu-api-server/values.yaml
@@ -65,7 +65,8 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-extraEnv: {}
+extraEnv: []
+extraEnvFrom: []
 
 podAnnotations: {}
 

--- a/charts/kamu-oracle-provider/Chart.yaml
+++ b/charts/kamu-oracle-provider/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kamu-oracle-provider
 description: Oracle provider that uses Kamu Node to supply data to blockchain smart contracts
 type: application
-version: 0.29.5
+version: 0.29.6
 appVersion: "0.29.1"
 home: https://kamu.dev
 icon: https://www.kamu.dev/images/kamu_logo_icon_bg_square.png

--- a/charts/kamu-oracle-provider/templates/deployment.yaml
+++ b/charts/kamu-oracle-provider/templates/deployment.yaml
@@ -42,10 +42,13 @@ spec:
               value: "1"
             - name: RUST_LOG
               value: {{ .Values.app.logLevel | quote }}
-            {{- range $key, $value := .Values.extraEnv }}
-            - name: {{ $key | quote }}
-              value: {{ $value | quote }}
+            {{- with .Values.extraEnv }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- with .Values.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: configs
               subPath: config.yaml

--- a/charts/kamu-oracle-provider/values.schema.json
+++ b/charts/kamu-oracle-provider/values.schema.json
@@ -18,6 +18,107 @@
           "properties": {}
         }
       }
+    },
+    "extraEnv": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "valueFrom": {
+            "type": "object",
+            "properties": {
+              "configMapKeyRef": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "object"
+                  },
+                  "optional": {
+                    "type": "boolean"
+                  }
+                }
+              },
+              "fieldRef": {
+                "type": "object",
+                "properties": {
+                  "apiVersion": {
+                    "type": "string"
+                  },
+                  "fieldPath": {
+                    "type": "string"
+                  }
+                }
+              },
+              "resourceFieldRef": {
+                "type": "object",
+                "properties": {
+                  "resource": {"type": "string"},
+                  "containerName": {"type": "string"},
+                  "divisor": {"type": "string"}
+                }
+              },
+              "secretKeyRef": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "object"
+                  },
+                  "optional": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "extraEnvFrom": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "configMapRef": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "optional": {
+                "type": "boolean"
+              }
+            }
+          },
+          "prefix": {
+            "type": "string"
+          },
+          "secretRef": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "optional": "boolean"
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/charts/kamu-oracle-provider/values.yaml
+++ b/charts/kamu-oracle-provider/values.yaml
@@ -44,7 +44,8 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-extraEnv: {}
+extraEnv: []
+extraEnvFrom: []
 
 podAnnotations: {}
 

--- a/charts/kamu-web-ui/Chart.yaml
+++ b/charts/kamu-web-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kamu-web-ui
 description: Web frontend component of the Kamu Compute Node
 type: application
-version: 0.25.1
+version: 0.25.2
 appVersion: "0.25.1"
 home: https://kamu.dev
 icon: https://www.kamu.dev/images/kamu_logo_icon_bg_square.png

--- a/charts/kamu-web-ui/templates/deployment.yaml
+++ b/charts/kamu-web-ui/templates/deployment.yaml
@@ -35,6 +35,14 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/charts/kamu-web-ui/values.schema.json
+++ b/charts/kamu-web-ui/values.schema.json
@@ -1,64 +1,171 @@
 {
-    "$schema": "http://json-schema.org/schema#",
-    "type": "object",
-    "required": [
-        "app"
-    ],
-    "properties": {
-        "app": {
-            "type": "object",
-            "required": [
-                "config"
-            ],
-            "properties": {
-                "config": {
-                    "type": "object",
-                    "required": [
-                        "apiServerGqlUrl",
-                        "apiServerHttpUrl",
-                        "githubClientId",
-                        "featureFlags"
-                    ],
-                    "properties": {
-                        "apiServerGqlUrl": {
-                            "type": "string",
-                            "format": "uri",
-                            "minLength": 1
-                        },
-                        "apiServerHttpUrl": {
-                            "type": "string",
-                            "format": "uri",
-                            "minLength": 1
-                        },
-                        "githubClientId": {
-                            "type": "string",
-                            "minLength": 1
-                        },
-                        "ingestUploadFileLimitMb": {
-                            "type": "integer",
-                            "minimum": 1
-                        },
-                        "featureFlags": {
-                            "type": "object",
-                            "required": [
-                                "enableLogout",
-                                "enableScheduling"
-                            ],
-                            "properties": {
-                                "enableLogout": {
-                                    "type": "boolean"
-                                },
-                                "enableScheduling": {
-                                    "type": "boolean"
-                                },
-                                "enableDatasetEnvVarsManagment": {
-                                    "type": "boolean"
-                                }
-                            }
-                        }
-                    }
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "required": [
+    "app"
+  ],
+  "properties": {
+    "app": {
+      "type": "object",
+      "required": [
+        "config"
+      ],
+      "properties": {
+        "config": {
+          "type": "object",
+          "required": [
+            "apiServerGqlUrl",
+            "apiServerHttpUrl",
+            "githubClientId",
+            "featureFlags"
+          ],
+          "properties": {
+            "apiServerGqlUrl": {
+              "type": "string",
+              "format": "uri",
+              "minLength": 1
+            },
+            "apiServerHttpUrl": {
+              "type": "string",
+              "format": "uri",
+              "minLength": 1
+            },
+            "githubClientId": {
+              "type": "string",
+              "minLength": 1
+            },
+            "ingestUploadFileLimitMb": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "featureFlags": {
+              "type": "object",
+              "required": [
+                "enableLogout",
+                "enableScheduling"
+              ],
+              "properties": {
+                "enableLogout": {
+                  "type": "boolean"
+                },
+                "enableScheduling": {
+                  "type": "boolean"
+                },
+                "enableDatasetEnvVarsManagment": {
+                  "type": "boolean"
                 }
+              }
             }
+          }
         }
+      }
+    },
+    "extraEnv": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "valueFrom": {
+            "type": "object",
+            "properties": {
+              "configMapKeyRef": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "object"
+                  },
+                  "optional": {
+                    "type": "boolean"
+                  }
+                }
+              },
+              "fieldRef": {
+                "type": "object",
+                "properties": {
+                  "apiVersion": {
+                    "type": "string"
+                  },
+                  "fieldPath": {
+                    "type": "string"
+                  }
+                }
+              },
+              "resourceFieldRef": {
+                "type": "object",
+                "properties": {
+                  "resource": {
+                    "type": "string"
+                  },
+                  "containerName": {
+                    "type": "string"
+                  },
+                  "divisor": {
+                    "type": "string"
+                  }
+                }
+              },
+              "secretKeyRef": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "object"
+                  },
+                  "optional": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "extraEnvFrom": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "configMapRef": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "optional": {
+                "type": "boolean"
+              }
+            }
+          },
+          "prefix": {
+            "type": "string"
+          },
+          "secretRef": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "optional": "boolean"
+              }
+            }
+          }
+        }
+      }
     }
+  }
 }

--- a/charts/kamu-web-ui/values.yaml
+++ b/charts/kamu-web-ui/values.yaml
@@ -49,6 +49,9 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+extraEnv: []
+extraEnvFrom: []
+
 podAnnotations: {}
 
 podSecurityContext: {}


### PR DESCRIPTION
Change `extraEnv` from key / value mapping to a object, that is directly inserted into a template. It allows usage of environment variables other than plain text values. For example:

```yaml
extraEnv:
  - name: NODE_IP
    valueFrom:
      fieldRef:
        fieldPath: status.hostIP
```