### PR TITLE
Temporarily disable linting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,15 +23,15 @@ jobs:
           fetch-depth: 0 # to pull repo with all history
       
       # Lint values schemas
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - uses: swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: rust-script
-      - run: rust-script tools/update_values_schemas.rs
-      - run: git diff && git diff-index --quiet HEAD
+#      - uses: actions-rust-lang/setup-rust-toolchain@v1
+#      - uses: swatinem/rust-cache@v2
+#        with:
+#          cache-on-failure: true
+#      - uses: taiki-e/install-action@v2
+#        with:
+#          tool: rust-script
+#      - run: rust-script tools/update_values_schemas.rs
+#      - run: git diff && git diff-index --quiet HEAD
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
Follow-up for:
- https://github.com/kamu-data/helm-charts/pull/113

Since we have a snapshot of `kamu-node` changes that aren't in the master branch, we have to take a workaround:
- Linting generates check schema for a config based on a tag that is missing